### PR TITLE
logging.Formatter compatibility

### DIFF
--- a/betterlogging/colorized.py
+++ b/betterlogging/colorized.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import sys
 from logging import Formatter
 from logging import LogRecord
 
@@ -43,7 +44,18 @@ class ColorizedFormatter(Formatter):
         self._formatter = ExceptionFormatter(colorize=True, backtrace=False, diagnose=True,
                                              hide_lib_diagnose=hide_lib_diagnose)
 
-        super().__init__(fmt=fmt, datefmt=datefmt, style=style, validate=validate, defaults=defaults)
+        kwargs = {
+            'fmt': fmt,
+            'datefmt': datefmt,
+            'style': style
+        }
+
+        if sys.version_info.minor > 7:
+            kwargs['validate'] = validate
+        if sys.version_info.minor > 9:
+            kwargs['defaults'] = defaults
+
+        super().__init__(**kwargs)
 
     def format(self, record: LogRecord) -> str:
         color = self.level_colors.get(record.levelno, self.level_colors.get(None, ""))

--- a/betterlogging/colorized.py
+++ b/betterlogging/colorized.py
@@ -27,13 +27,23 @@ DEFAULT_LEVEL_COLORS = {
 
 
 class ColorizedFormatter(Formatter):
-    def __init__(self, fmt=None, level_colors=None, hide_lib_diagnose=True, *args, **kwargs):
+    def __init__(
+            self,
+            fmt=None,
+            datefmt=None,
+            style='%',
+            validate=True,
+            *,
+            defaults=None,
+            level_colors=None,
+            hide_lib_diagnose=True
+    ):
         self.level_colors = level_colors or DEFAULT_LEVEL_COLORS
         fmt = fmt or DEFAULT_FORMAT
         self._formatter = ExceptionFormatter(colorize=True, backtrace=False, diagnose=True,
                                              hide_lib_diagnose=hide_lib_diagnose)
 
-        super().__init__(fmt=fmt, *args, **kwargs)
+        super().__init__(fmt=fmt, datefmt=datefmt, style=style, validate=validate, defaults=defaults)
 
     def format(self, record: LogRecord) -> str:
         color = self.level_colors.get(record.levelno, self.level_colors.get(None, ""))

--- a/betterlogging/colorized.py
+++ b/betterlogging/colorized.py
@@ -47,13 +47,15 @@ class ColorizedFormatter(Formatter):
         kwargs = {
             'fmt': fmt,
             'datefmt': datefmt,
-            'style': style
+            'style': style,
+            'validate': validate,
+            'defaults': defaults
         }
 
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
-            kwargs['validate'] = validate
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-            kwargs['defaults'] = defaults
+        if sys.version_info.major == 3 and sys.version_info.minor < 8:
+            del kwargs['validate']
+        if sys.version_info.major == 3 and sys.version_info.minor < 10:
+            del kwargs['defaults']
 
         super().__init__(**kwargs)
 

--- a/betterlogging/colorized.py
+++ b/betterlogging/colorized.py
@@ -50,9 +50,9 @@ class ColorizedFormatter(Formatter):
             'style': style
         }
 
-        if sys.version_info.minor > 7:
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
             kwargs['validate'] = validate
-        if sys.version_info.minor > 9:
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
             kwargs['defaults'] = defaults
 
         super().__init__(**kwargs)


### PR DESCRIPTION
We need to keep signature compatibility of base logging classes
The Formatter's init method was with the different signature